### PR TITLE
feat: _siteディレクトリを.gitignoreに追加 #26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+vendor


### PR DESCRIPTION
## 概要
Jekyllのビルド成果物である`_site`ディレクトリを`.gitignore`に追加し、GitHubリポジトリから除外します。

## 変更内容
- `.gitignore`ファイルを新規作成
- 以下のディレクトリ/ファイルを除外対象に追加：
  - `_site/` - Jekyllのビルド成果物
  - `.sass-cache/` - Sassのキャッシュ
  - `.jekyll-cache/` - Jekyllのキャッシュ
  - `.jekyll-metadata` - Jekyllのメタデータ
  - `vendor` - vendorディレクトリ

## 関連Issue
Closes #26

## 確認項目
- [x] `.gitignore`ファイルが正しく作成されている
- [x] 標準的なJekyllプロジェクトの除外パターンを含んでいる
- [x] ローカルでJekyllビルドが正常に動作することを確認

## 背景
現在、ビルド成果物である`_site`ディレクトリがリポジトリに含まれているため、これを除外対象とすることで：
- リポジトリサイズの削減
- 不要なコミット履歴の防止
- GitHub Pagesでの自動ビルドとの整合性確保

を実現します。