### PR TITLE
feat: PR作成時に自動でプレビュー環境を構築する #27

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,40 @@
+name: Cleanup PR Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove preview directory
+        run: |
+          if [ -d "pr-preview/${{ github.event.pull_request.number }}" ]; then
+            rm -rf pr-preview/${{ github.event.pull_request.number }}
+            echo "Preview directory removed"
+          else
+            echo "Preview directory not found"
+          fi
+
+      - name: Commit and push cleanup
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "🧹 Remove preview for PR #${{ github.event.pull_request.number }}"
+            git push
+          fi

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -31,10 +31,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
+          git add pr-preview/${{ github.event.pull_request.number }} || true
           if git diff --quiet && git diff --staged --quiet; then
             echo "No changes to commit"
           else
             git commit -m "🧹 Remove preview for PR #${{ github.event.pull_request.number }}"
             git push
+
           fi

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -30,7 +32,7 @@ jobs:
           bundle exec jekyll build --baseurl "/pr-preview/${{ github.event.pull_request.number }}"
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
@@ -82,23 +84,3 @@ jobs:
                 body: comment
               });
             }
-
-  cleanup:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-
-      - name: Remove preview directory
-        run: |
-          rm -rf pr-preview/${{ github.event.pull_request.number }}
-          
-      - name: Commit and push cleanup
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-          git add .
-          git diff --quiet && git diff --staged --quiet || (git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}" && git push)

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   pages: write
   id-token: write

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0'
-          bundler-cache: true
+          bundler-cache: false
 
       - name: Build Jekyll site
         run: |

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,103 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  pages: write
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          bundler-cache: true
+
+      - name: Build Jekyll site
+        run: |
+          bundle install
+          bundle exec jekyll build --baseurl "/pr-preview/${{ github.event.pull_request.number }}"
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          destination_dir: pr-preview/${{ github.event.pull_request.number }}
+          keep_files: true
+
+      - name: Comment PR with preview URL
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const repoName = context.repo.repo;
+            const ownerName = context.repo.owner;
+            const previewUrl = `https://${ownerName}.github.io/${repoName}/pr-preview/${prNumber}/`;
+            
+            const comment = `🚀 **プレビュー環境が作成されました！**
+            
+            プレビューURL: ${previewUrl}
+            
+            このプレビューは、PRが更新されるたびに自動的に更新されます。`;
+            
+            // 既存のコメントを検索
+            const comments = await github.rest.issues.listComments({
+              owner: ownerName,
+              repo: repoName,
+              issue_number: prNumber
+            });
+            
+            const botComment = comments.data.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('プレビュー環境が作成されました')
+            );
+            
+            if (botComment) {
+              // 既存のコメントを更新
+              await github.rest.issues.updateComment({
+                owner: ownerName,
+                repo: repoName,
+                comment_id: botComment.id,
+                body: comment
+              });
+            } else {
+              // 新規コメントを作成
+              await github.rest.issues.createComment({
+                owner: ownerName,
+                repo: repoName,
+                issue_number: prNumber,
+                body: comment
+              });
+            }
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove preview directory
+        run: |
+          rm -rf pr-preview/${{ github.event.pull_request.number }}
+          
+      - name: Commit and push cleanup
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+          git add .
+          git diff --quiet && git diff --staged --quiet || (git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}" && git push)

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Build Jekyll site
         run: |
+          bundle lock --add-platform x86_64-linux
           bundle install
           bundle exec jekyll build --baseurl "/pr-preview/${{ github.event.pull_request.number }}"
 


### PR DESCRIPTION
## 概要
プルリクエスト作成時に自動的にプレビュー環境を構築し、変更内容を確認できるようにするGitHub Actionsワークフローを実装しました。

## 実装内容

### 1. PRプレビューワークフロー (.github/workflows/pr-preview.yml)
- PR作成・更新時に自動実行
- Jekyllサイトをビルドし、PR番号ごとの専用URLでデプロイ
- プレビューURLをPRコメントに自動投稿
- 既存コメントがある場合は更新

### 2. プレビュークリーンアップワークフロー (.github/workflows/pr-preview-cleanup.yml)
- PRクローズ時に自動実行
- 該当するプレビュー環境を削除
- gh-pagesブランチから不要なディレクトリを除去

## 機能

- **自動デプロイ**: PR作成・更新時に自動的にプレビュー環境構築
- **専用URL**: `https://{owner}.github.io/{repo}/pr-preview/{pr-number}/` 形式
- **コメント通知**: プレビューURLをPRコメントに自動投稿・更新
- **自動クリーンアップ**: PRクローズ時にプレビュー環境を自動削除
- **Jekyll対応**: 既存のGemfile設定を活用したビルド

## 設定要件

このワークフローを使用するために以下の設定が必要です：

1. **GitHub Pages有効化**
   - Settings > Pages > Source: "Deploy from a branch"
   - Branch: "gh-pages" / "(root)"

2. **必要な権限**
   - `contents: read/write`
   - `pull-requests: write`
   - `pages: write`
   - `id-token: write`

## 使用方法

1. PRを作成すると自動的にプレビュー環境が構築されます
2. プレビューURLがPRコメントに投稿されます
3. PRを更新するとプレビューも自動更新されます
4. PRをクローズ・マージするとプレビュー環境が自動削除されます

## 関連Issue
Closes #27

## テスト計画
- [ ] このPR自体でプレビュー機能が動作することを確認
- [ ] プレビューURLが正しく生成されることを確認
- [ ] PRコメントが適切に投稿・更新されることを確認
- [ ] PRクローズ時にクリーンアップが動作することを確認

## 注意事項
- 初回実行時はGitHub Pagesの設定確認が必要な場合があります
- プレビュー環境は公開されるため、機密情報を含まないように注意してください

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated deployment of preview environments for pull requests, providing a unique preview URL for each PR.
  * Added automatic posting and updating of preview URLs as comments on pull requests.
  * Implemented automatic cleanup of preview environments when pull requests are closed, ensuring outdated previews are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->