### PR TITLE
Fix heading line-height to prevent Japanese text overlap

### DIFF
--- a/_sass/base/general.sass
+++ b/_sass/base/general.sass
@@ -11,6 +11,7 @@ h1, h2, h3, h4
 	color: $beta
 	-webkit-font-smoothing: antialiased
 	text-rendering: optimizeLegibility
+	line-height: 1.6
 
 h1
 	font-size: 3rem


### PR DESCRIPTION
## Summary

- `h1, h2, h3, h4` に `line-height: 1.6` を追加
- 日本語テキストを含む見出しが折り返す際の文字重なりを修正
- 特に about ページの長い h3 見出し（例：熊本大学の経歴）で顕著だった問題を解消

## 原因

`h1, h2, h3, h4` の `line-height` が未設定でブラウザデフォルトの `normal`（≈1.2倍）が適用されていた。日本語文字は em-box をほぼ全体に占有するため、20px フォントサイズでは行間が約 4px しかなく、複数行にまたがる見出しで文字が重なって見えていた。

## Test plan

- [ ] https://saeeeeru.github.io/about/ を開き、長い見出しテキストが正しく表示されることを確認
- [ ] 各ページ（Home, Projects, About）で見出しのレイアウトが崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved heading typography with enhanced vertical spacing for better visual presentation across all pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->