### PR TITLE
Fix li line-height for Japanese text overlap

### DIFF
--- a/_sass/base/general.sass
+++ b/_sass/base/general.sass
@@ -50,7 +50,7 @@ strong
 ul,
 ol
 	li
-		line-height: 2.4rem
+		line-height: 1.8
 		font-weight: 300
 		color: $alpha
 


### PR DESCRIPTION
## Summary

- `li` の `line-height` を `2.4rem`（実質 1.5 倍）から `1.8` に変更

## 原因

`li` の `line-height: 2.4rem` は 1rem=10px のため 24px。`li` の font-size は body から継承した 16px なので行間比率は **1.5 倍**。`p` の `line-height: 1.7` に比べて狭く、日本語テキストが折り返す際に文字が重なっていた（例: about ページの「赤い彗星と呼ばれる〜」）。

## Test plan

- [ ] https://saeeeeru.github.io/about/ で「赤い彗星と呼ばれる〜」のリストアイテムが重ならず表示されることを確認
- [ ] 他のページのリストアイテムも正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted list item line-height to improve readability and visual spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->