### PR TITLE
Adjust li spacing: narrow line-height, add margin between items

### DIFF
--- a/_sass/base/general.sass
+++ b/_sass/base/general.sass
@@ -50,7 +50,8 @@ strong
 ul,
 ol
 	li
-		line-height: 1.8
+		line-height: 1.6
+		margin-bottom: 0.6em
 		font-weight: 300
 		color: $alpha
 


### PR DESCRIPTION
## Summary

- `line-height: 1.8 → 1.6`（行間をやや狭く）
- `margin-bottom: 0.6em` 追加（li 間の余白を行間より広めに）

行内の折り返し間隔と、リストアイテム同士の間隔を視覚的に区別しやすくする。

## Test plan

- [ ] about ページのリストアイテムで行間 < アイテム間余白になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)